### PR TITLE
fix: align tags inline with title in preview and remove underline in post view

### DIFF
--- a/src/components/post/post-article.tsx
+++ b/src/components/post/post-article.tsx
@@ -34,7 +34,7 @@ export default function PostArticle({
                 key={tag}
                 to={`/${type}`}
                 search={{ tag }}
-                className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
+                className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors no-underline"
               >
                 {tag}
               </Link>

--- a/src/components/post/post-preview.tsx
+++ b/src/components/post/post-preview.tsx
@@ -23,24 +23,26 @@ export default function PostPreview({
     <li key={slug} className="flex flex-col gap-1">
       <div className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-4">
         <time className="text-sm text-gray-400 shrink-0 tabular-nums">{date}</time>
-        <Link to={url} className="hover:text-gray-600">
-          {title}
-        </Link>
-      </div>
-      {tags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 sm:ml-[6.5rem]">
-          {tags.map((tag) => (
-            <button
-              key={tag}
-              type="button"
-              onClick={() => onTagClick?.(tag)}
-              className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
-            >
-              {tag}
-            </button>
-          ))}
+        <div className="flex items-baseline justify-between gap-4 min-w-0 flex-1">
+          <Link to={url} className="hover:text-gray-600 min-w-0">
+            {title}
+          </Link>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 shrink-0">
+              {tags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => onTagClick?.(tag)}
+                  className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition-colors"
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </li>
   );
 }


### PR DESCRIPTION
## Summary
- Tags in post preview now appear inline with the title (right-aligned) instead of below it
- Tags in the post article view no longer show underlines

## Changes
- `post-preview.tsx`: wrapped title and tags in a `flex justify-between` container so they sit side-by-side on the same row
- `post-article.tsx`: added `no-underline` to tag `<Link>` class to suppress inherited underline styling

## Test plan
- Visit the blog/til list page and confirm tags appear on the same line as the post title, pushed to the right
- Open a post and confirm tags render as pills without underlines