### PR TITLE
feat: add drop shadow to images

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-.prose img {
+img {
   box-shadow:
     0 4px 16px 0 rgba(0, 0, 0, 0.08),
     0 0 0 1px rgba(0, 0, 0, 0.04);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,12 @@
 @tailwind components;
 @tailwind utilities;
 
+.prose img {
+  box-shadow:
+    0 4px 16px 0 rgba(0, 0, 0, 0.08),
+    0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
 .prose section {
   padding-top: 1rem;
   padding-bottom: 1rem;

--- a/src/components/mdx-component.tsx
+++ b/src/components/mdx-component.tsx
@@ -123,7 +123,13 @@ export const mdxComponents: MDXComponents = {
     );
   },
   img: ({ src, alt, ...props }) => (
-    <img src={src} alt={alt || ""} loading="lazy" className="my-4 max-w-full rounded" {...props} />
+    <img
+      src={src}
+      alt={alt || ""}
+      loading="lazy"
+      className="my-4 max-w-full rounded-md"
+      {...props}
+    />
   ),
   blockquote: (props) => (
     <blockquote className="border-l-2 border-gray-200 pl-4 italic my-4 text-gray-600" {...props} />


### PR DESCRIPTION
## Summary
- Add subtle drop shadow styling to all images site-wide
- Improves visual hierarchy and depth perception

## Changes
- Added `img` selector in `globals.css` with `box-shadow` styling
- Applies consistent shadow effect across blog posts and all pages

## Test plan
1. Check blog post pages — images should have visible drop shadows
2. Check homepage and other pages — all images should have shadows
3. Verify shadows are subtle and don't overwhelm content