### PR TITLE
fix: prevent layout shift when navigating between pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,9 @@ img {
   * {
     @apply border-gray-200;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     @apply bg-white text-gray-900;
     font-family: "Pretendard Variable", Pretendard, sans-serif;

--- a/src/components/site/site-header.tsx
+++ b/src/components/site/site-header.tsx
@@ -5,7 +5,7 @@ export default function SiteHeader() {
 
   const linkClass = (path: string) => {
     const active = path === "/" ? pathname === "/" : pathname.startsWith(path);
-    return active ? "text-gray-900 font-semibold" : "text-gray-400";
+    return active ? "text-gray-900" : "text-gray-400";
   };
 
   return (
@@ -17,7 +17,7 @@ export default function SiteHeader() {
         >
           꼬깜
         </Link>
-        <div className="flex gap-4 text-sm">
+        <div className="flex gap-4 text-sm font-semibold">
           <Link to="/blog" className={`no-underline hover:text-gray-900 ${linkClass("/blog")}`}>
             blog
           </Link>


### PR DESCRIPTION
## Summary
- Reserve scrollbar gutter space to prevent 15px content shift when scrollbar appears/disappears
- Stabilize nav link font-weight to prevent text reflow on active state changes

## Changes
**globals.css:**
- Added `scrollbar-gutter: stable` to `html` element to reserve space for scrollbar gutter

**site-header.tsx:**
- Removed `font-semibold` from active link state (text-gray-900 now applies color only)
- Added `font-semibold` to nav links container to apply consistent font-weight always

This prevents layout shifts caused by font-weight changes between active/inactive states and scrollbar appearance/disappearance.

## Test plan
- Navigate between home page (with canvas) and other pages (blog, about, til)
- Verify that the layout does not shift when scrollbar appears/disappears
- Verify that nav links maintain consistent width when changing between active and inactive states