### PR TITLE
fix: add permissions section to pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  check:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,7 +3,8 @@ name: Pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the pre-commit workflow to enable the workflow to make commits or push changes when needed

## Changes

Added a `permissions` section to `.github/workflows/pre-commit.yaml` that grants the workflow write access to repository contents. This is necessary for CI workflows that need to commit changes (such as formatting fixes, auto-generated files, or dependency updates).

## Test plan

- The pre-commit workflow will now have the necessary permissions to execute write operations
- Verify that the workflow runs without permission-related errors
- Check that any intended commit operations in the workflow complete successfully